### PR TITLE
feat: add "Contribute" link to the navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@ style: boxed
       <li class="grid-3-lil"><a href="https://www.chromium.org/Home/chromium-security/core-principles/" class="box">Core principles</a></li>
       <li class="grid-3-lil"><a href="https://www.chromium.org/Home/chromium-security/quarterly-updates/" class="box">Quarterly updates</a></li>
       <li class="grid-3-lil"><a href="https://bughunters.google.com/about/rules/5745167867576320/chrome-vulnerability-reward-program-rules" class="box">Vulnerability Rewards</a></li>
+      <li class="grid-3-lil"><a href="https://github.com/chromium/chrome.security" class="box">Contribute</a></li>
     </ul>
   </nav>
 


### PR DESCRIPTION
## Summary
Adds a "Contribute" link to the navigation menu on chrome.security, linking to this GitHub repository.

## Changes
- Added a new navigation card in [index.html](cci:7://file:///home/muntazir/Desktop/gs2.6/chrome.security/index.html:0:0-0:0) that links to `https://github.com/chromium/chrome.security`
- Follows the same styling as existing navigation items (`grid-3-lil` + `box` classes)

## Why
This makes the relationship between the chrome.security website and this GitHub repository more obvious, helping contributors (like the Chrome Root Program team) understand how to submit updates or reference new blog posts.

Fixes #13